### PR TITLE
Add link to a IIIF intro in "Tutorials" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Tutorials for how to accomplish functionality in your applications.
 - [IIIF Quick Start Guide](http://iiif.io/technical-details/) is a quick overview of how you might get started with implementing various IIIF standards.
 - [Drag and Drop](https://medium.com/@aeschylus/create-and-share-iiif-items-quickly-and-easily-with-drag-and-drop-over-email-879f13c9caba) a IIIF image into Mirador
 - [Fellow Travelers: The Canterbury Tales and IIIF](http://web.stanford.edu/group/dmstech/cgi-bin/wordpress/author/blalbrit/) by Benjamin Albritton includes an explanation of the use case for medieval scholars using Chaucer as an example and short section on how to make a page comparison demo in Mirador.
+- [IIIF Intro (fr)](http://doc.biblissima-condorcet.fr/introduction-iiif) Introduction to IIIF (in French)
 
 ## Slide Decks
 


### PR DESCRIPTION
It is not really a tutorial, it is only a set of web pages giving a broad intro to IIIF ("raison d'être" of the initiative, overview of the two main APIs, links etc.). The most interesting is that it is in french (the only intro in french as far as I know...)