### PR TITLE
Added IIIF_S3 to the image server list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ These servers support the IIIF Image API.
 - [RAIS](https://github.com/uoregon-libraries/rais-image-server) 100% open source tile server for JP2 images written in Go
 - [digilib](http://digilib.sourceforge.net) image server written in Java
 - [Cantaloupe](https://github.com/medusa-project/cantaloupe) image server written in Java
-
+- [iiif_s3](https://github.com/cmoa/iiif_s3) Ruby library for generating a static IIIF level 0 Image and Presentation API server on Amazon S3
 
 ## Image Server Shims
 


### PR DESCRIPTION
This should address issue #31.  Wasn't 100% sure where to stick it—it is an image server, but it's also a Presentation API library.  Happy to move it wherever.