### PR TITLE
Added musiclibs.net

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ Links to help you discover IIIF resources that have been shared, demonstrations 
 - [iiif-universe](https://github.com/ryanfb/iiif-universe) is a repository that includes links to known IIIF presentation manifest collections.
 - [iNQUIRE demo](http://inquire.armtest.uk/) is a demo of an open-source IIIF-compliant research and discovery platform. This is the IIIF-compliant version of the platform driving [Digital Bodleian] (http://digital.bodleian.ox.ac.uk/)
 - [iNQUIRE source](https://github.com/armadillo-systems/inquire) is the Github repository for iNQUIRE.
+- [Musiclibs](musiclibs.net) provides cross-library search of thousands of musical scores and manuscripts.
 
 ## Implementations
 


### PR DESCRIPTION
Musiclibs is a project which aggregates IIIF manifests representing music documents and indexes them for cross-library search.