### PR TITLE
Fixed musiclibs.net link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ Links to help you discover IIIF resources that have been shared, demonstrations 
 - [iiif-universe](https://github.com/ryanfb/iiif-universe) is a repository that includes links to known IIIF presentation manifest collections.
 - [iNQUIRE demo](http://inquire.armtest.uk/) is a demo of an open-source IIIF-compliant research and discovery platform. This is the IIIF-compliant version of the platform driving [Digital Bodleian] (http://digital.bodleian.ox.ac.uk/)
 - [iNQUIRE source](https://github.com/armadillo-systems/inquire) is the Github repository for iNQUIRE.
-- [Musiclibs](musiclibs.net) provides cross-library search of thousands of musical scores and manuscripts.
+- [Musiclibs](https://musiclibs.net) provides cross-library search of thousands of musical scores and manuscripts.
 
 ## Implementations
 


### PR DESCRIPTION
I did not realise github would treat the url as a github project unless it began with `http`. My mistake!