### PR TITLE
Add hocrviewer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Sites which have implemented IIIF in some respect. Note what standards or other 
 - [NCSU Libraries Rare and Unique Digital Collections](https://twitter.com/vaticanlibrary/status/732546207457935360) implements the Image, Presentation, and Content Search APIs.
 - [DigiVatLib](http://digi.vatlib.it/) provides access to digitized collections from the Vatican.
 - [Georeferencer](http://www.georeferencer.com/) can take maps accessible via IIIF and referenced to modern maps.
+- [hocrviewer](https://github.com/jbaiter/hocrviewer-mirador) can display and search OCRed documents in the [hOCR format](http://kba.github.io/hocr-spec/1.2/) with Mirador. Contains a simple implementation of the Content Search API with SQLite.
 
 ## Newspapers
 


### PR DESCRIPTION
I developed a small Python application to help view and debug OCRed documents in the [hOCR format](http://kba.github.io/hocr-spec/1.2/) with Mirador.
It can use SQLite to store the OCR annotations and also implements the Content Search API (also with SQLite), which might be useful for implementers as a reference.
