### PR TITLE
Add browser extension: Open in IIIF Viewer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,10 @@ Links to help you discover IIIF resources that have been shared, demonstrations 
 - [iNQUIRE source](https://github.com/armadillo-systems/inquire) is the Github repository for iNQUIRE.
 - [Musiclibs](https://musiclibs.net) provides cross-library search of thousands of musical scores and manuscripts.
 
+### Import to Viewers
+
+- [Open in IIIF Viewer](https://github.com/2SC1815J/open-in-iiif-viewer) - A web browser extension to open IIIF manifest link in your favorite IIIF viewer. 
+
 ## Annotations
 
 While annotations are not specified by IIIF they are an important enabling technology.


### PR DESCRIPTION
https://github.com/IIIF/awesome-iiif/issues/177
(formerly named “Open IIIF Manifest Link in Favorite Viewer.”)

Where is the best place to add this item?

1. Create “Import to Viewers” subsection under “Discovery” section.
2. Create “Web Browser Extensions” section.
3. Add to the end of “Experiments and Fun.”

Reason for 1:
- This browser extension provides an interim solution to some part of “Import to viewers” which is one of four key areas of “Discovery.”

> - Import to viewers
>   - How do I get IIIF resources from their context of discovery into the viewing environment of my choice?
>
> (cited from “[IIIF Discovery Technical Specification Group](https://drive.google.com/file/d/104U6l5XiYaDdreHnUzBiG2C8tW4HOH7l/view)” p.4)

Reason for 2:
- If there are at least two web browser extensions to add to the list (for the future?), it would be better to collect in one category.

Reason for 3:
- Changes to the list are minimal.

This proposal adopts plan one tentatively. I would appreciate it if there is any better edit.