### PR TITLE
Add `iiif-producer` from UB Leipzig

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,8 @@ These shims allow you to use systems with presentation metadata (e.g. structure 
 - [Manifest Editor](https://github.com/bodleian/iiif-manifest-editor) - Web application for importing, viewing, updating, and exporting manifests. See a [demo](http://morning-journey-27147.herokuapp.com/#/?_k=agcbor).
 - [demetsiiify](https://github.com/jbaiter/demetsiiify) - Web service for creating IIIF manifests from METS/MODS documents.
 - [biiif](https://github.com/edsilv/biiif/) - Organise your files according to a simple naming convention to generate IIIF v3 manifests.
+- [iiif-producer](https://github.com/ubleipzig/iiif-producer) - A CLI tool that generates IIIF Presentation 2.1 Manifests from METS/MODS (produced by Kitodo)
+
 
 ## Content Search API
 


### PR DESCRIPTION
Just discovered this: https://github.com/ubleipzig/iiif-producer

> A CLI tool that generates IIIF Presentation 2.1 Manifests from METS/MODS (produced by Kitodo)