### PR TITLE
Removes TryIIIF service (being retired)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,6 @@ Various tools for working with images such as cropping tools.
 - [Stanford Cropper](https://github.com/lizfischer/iiif-tools#cropper) - Simple image cropper.
 - [OpenSeadragon Cropping Tool](http://sul-dlss.github.io/iiif-cropper/demo/) - Script to allow for cropping an image from within OpenSeadragon.
 - [Wikimedia Commons Image Cropper](http://zone47.com/crotos/lab/cropper/) - Create IIIF image regions from image files at Wikimedia Commons.
-- [TryIIIF](http://tryiiif.herokuapp.com/) - Example tool for viewing any web-accessible image within a couple IIIF Image Viewers.
 - [IIIF-imageManipulation](https://github.com/jbhoward-dublin/iiif-imageManipulation) - UCD's tool to crop images and manipulate via IIIF attributes; integrate with Mirador via plugin.
 - [Compariscope](https://vanda.github.io/iiif-features/) - A demo app by the Victoria & Albert useful for the alignment of overlayed images, served by the IIIF Image API, and providing an interactive viewer for overlayed images, presented fluidly, using responsive image tags.
 


### PR DESCRIPTION
This removes the TryIIIF service from the list. We're retiring TryIIIF, so it won't be around anymore.

If anyone else in the community wants to take over the service, the repo for it is at https://github.com/mitlibraries/tryiiif