### PR TITLE
add Image API playground from learniiif.org to Tutorials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Some resources about the IIIF Authentication API.
 
 Tutorials for how to accomplish functionality in your applications.
 
-- [IIIF Image API live demo](http://yenda.tools/en/iiif-api-demo-en/) - Learn about the structure of a IIIF URL through manipulating the parameters and seeing the results in a live demo.
+- [Image API Playground](https://www.learniiif.org/image-api/playground) - Learn about the structure of a IIIF URL through manipulating the parameters and seeing the results in a live demo.
 - [IIIF Implementation Guide](http://iiif.io/assets/acc_implementation_guide_011017.pdf)  A step-by-step walkthrough of how to implement IIIF.
 - [IIIF Quick Start Guide](http://iiif.io/technical-details/) is a quick overview of how you might get started with implementing various IIIF standards.
 - [Drag and Drop](https://medium.com/@aeschylus/create-and-share-iiif-items-quickly-and-easily-with-drag-and-drop-over-email-879f13c9caba) a IIIF image into Mirador.


### PR DESCRIPTION
replacing the broken link (fixes #253)