### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,6 @@ These shims allow you to use an image server that does not currently support III
 - [IIIF Curation Viewer](http://codh.rois.ac.jp/software/iiif-curation-viewer/) - A general IIIF viewer with added focus on curation and ordering of cropped IIIF images. [Demo](http://codh.rois.ac.jp/software/iiif-curation-viewer/demo/?curation=https://gist.githubusercontent.com/2SC1815J/18e1228c52a6650c64902142ed7496f8/raw/7a247b64b6e22357e83f573b7283e31f3111af68/curation_kibutsu.json&pos=4)
 - [CanvasPanel](http://canvas-panel.netlify.com/) is a React library to build IIIF Presentation 3 level viewing experiences including support for annotations.
 - [OpenLayers](https://openlayers.org) is an high-performance, feature-packed Javascript library especially built for maps. It supports the IIIF Image API 2.1.
-- [Goobi viewer](https://github.com/intranda/goobi-viewer-core) is an open source presentation software for digital libraries, museums, archives and galleries.
 
 ## Image API Libraries
 - [iiif-apis](https://github.com/dbmdz/iiif-apis) - Java IIIF API libraries.
@@ -284,6 +283,7 @@ IIIF is a community-based initiative that relies on active participation, discus
  - [Rosetta](https://knowledge.exlibrisgroup.com/Rosetta/Training/What's_New_Videos/Rosetta_5-3)
  - [Axiell Collections](https://www.axiell.com/solutions/product/axiell-collections/)
  - [Luna](http://www.lunaimaging.com/iiif)
+ - [Goobi viewer](https://github.com/intranda/goobi-viewer-core)
 
 ## License
 


### PR DESCRIPTION
Move Goobi viewer to the DAM section because it is more a complete digital library/archive/museum solution than a single image viewer.