### PR TITLE
Fix DAMS link in Contents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ The International Image Interoperability Framework (IIIF) is a group of standard
 - [STEM](#stem)
 - [Experiments and Fun](#experiments-and-fun)
 - [Community](#community)
-- [Digital Asset Management (DAMs)](#digital-asset-management (DAMs))
+- [Digital Asset Management (DAMs)](#digital-asset-management-dams-that-support-iiif)
 
 ## Standards
 


### PR DESCRIPTION
The current anchor link doesn't work because the section title changed at some point (I guess?).