### PR TITLE
Propose adding Simple Site IIIF extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ These shims allow you to use systems with presentation metadata (e.g. structure 
 - [biiif](https://github.com/edsilv/biiif/) - Organise your files according to a simple naming convention to generate IIIF v3 manifests.
 - [iiif-producer](https://github.com/ubleipzig/iiif-producer) - A CLI tool that generates IIIF Presentation 2.1 Manifests from METS/MODS (produced by Kitodo).
 - [File Analyzer IIIF Manifest Generator from Existing Metadata](http://georgetown-university-libraries.github.io/File-Analyzer-Test-Data/iiif/) - Georgetown's desktop application that will generate IIIF manifest files from existing metadata files.
-- [Simple Site IIIF Mirador Extension](https://jpadfield.github.io/simple-site/IIIF%20viewer.html) This [Simple Site](https://jpadfield.github.io/simple-site/) extension uses the IIIF image viewer Mirador to produce a customised presentation of a bespoke selection of IIIF manifests.
+- [Simple Site IIIF Extensions](https://jpadfield.github.io/simple-site/extensions.html) This [Simple Site](https://jpadfield.github.io/simple-site/) has several extensions that make use of IIIF to produce customised presentations of a bespoke selection of IIIF manifests (e.g. in Mirador 3, Curtain Viewer and Panel Truck).
 
 ## Content Search API
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ These shims allow you to use systems with presentation metadata (e.g. structure 
 - [biiif](https://github.com/edsilv/biiif/) - Organise your files according to a simple naming convention to generate IIIF v3 manifests.
 - [iiif-producer](https://github.com/ubleipzig/iiif-producer) - A CLI tool that generates IIIF Presentation 2.1 Manifests from METS/MODS (produced by Kitodo).
 - [File Analyzer IIIF Manifest Generator from Existing Metadata](http://georgetown-university-libraries.github.io/File-Analyzer-Test-Data/iiif/) - Georgetown's desktop application that will generate IIIF manifest files from existing metadata files.
+- [Simple Site IIIF Mirador Extension](https://jpadfield.github.io/simple-site/IIIF%20viewer.html) This [Simple Site](https://jpadfield.github.io/simple-site/) extension uses the IIIF image viewer Mirador to produce a customised presentation of a bespoke selection of IIIF manifests.
 
 ## Content Search API
 


### PR DESCRIPTION
I propose that we add @jpadfield's Simple Site project to the IIIF Awesome List.

I don't think that's controversial, but it does raise a few questions:

1. Where should it live? I put it under "Presentation Manifest Tools", but that doesn't feel perfect ... which brings me to:
2. Should we create a new section that also includes these two tools as well, which are potentially similar?
- https://github.com/minicomp/wax
- https://github.com/pbinkley/postwax

among others. 

Maybe a section like "Exhibition and Display tools"? I'd love to hear thoughts on this.