### PR TITLE
Add ReactOpenSeadragonViewer to Image Viewers list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ These shims allow you to use an image server that does not currently support III
 - [IIIF Curation Viewer](http://codh.rois.ac.jp/software/iiif-curation-viewer/) - A general IIIF viewer with added focus on curation and ordering of cropped IIIF images. [Demo](http://codh.rois.ac.jp/software/iiif-curation-viewer/demo/?curation=https://gist.githubusercontent.com/2SC1815J/18e1228c52a6650c64902142ed7496f8/raw/7a247b64b6e22357e83f573b7283e31f3111af68/curation_kibutsu.json&pos=4)
 - [CanvasPanel](http://canvas-panel.netlify.com/) - React library to build IIIF Presentation 3 level viewing experiences including support for annotations.
 - [OpenLayers](https://openlayers.org) - High-performance, feature-packed Javascript library especially built for maps. It supports the IIIF Image API 2.1.
+- [ReactOpenSeadragonViewer](https://www.npmjs.com/package/openseadragon-react-viewer) - A React wrapper component around OpenSeadragon which offers selectable, extended UI functionality.
 
 ## Image API Libraries
 - [iiif-apis](https://github.com/dbmdz/iiif-apis) - Java IIIF API libraries.


### PR DESCRIPTION
This PR adds the `ReactOpenSeadragonViewer` module to the Image Viewers list.  More details on the package here:

https://www.npmjs.com/package/openseadragon-react-viewer

Our team at Northwestern University uses an OpenSeadragon viewer in multiple applications, and creates UIs primary in React these days.  This package has served us well, and seems to have a consistent weekly download presence on NPM.

Here's an example usage:

https://digitalcollections.library.northwestern.edu/items/80b2dd3f-aded-4610-9391-b534a9545552#zoom=0.8145731375747689&x=0.5&y=0.34101023587004897

This package extends some functionality of the core OpenSeadragon UI, and the updates are configurable to switch on/off fairly easily.