### PR TITLE
Add aws-batch-iiif-generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ These servers support the IIIF Image API. Some may also have support for the Pre
 - [Hymir IIIF Server](https://github.com/dbmdz/iiif-server-hymir) - IIIF server written in Java supporting IIIF Image and Presentation API.
 - [go-iiif](https://github.com/thisisaaronland/go-iiif) - IIIF server written in go (fork of [greut/iiif](https://github.com/greut/iiif)).
 - [serverless-iiif](https://github.com/nulib/serverless-iiif) - IIIF Image API 2.1 server as an AWS Serverless Application.
+- [aws-batch-iiif-generator](https://github.com/vt-digital-libraries-platform/aws-batch-iiif-generator) - An automated pipeline to generate IIIF tiles and manifests and use AWS S3 as an IIIF image server.
 
 ## Image Server Shims
 


### PR DESCRIPTION
Add [aws-batch-iiif-generator](https://github.com/vt-digital-libraries-platform/aws-batch-iiif-generator). An automated pipeline to generate IIIF tiles and manifests and use AWS S3 as an IIIF image server. This work is also published in the Code4lib journal - [Scaling IIIF Image Tiling in the Cloud](https://journal.code4lib.org/articles/14933).