### PR TITLE
Add Cookbook, Guides, and validators to 'official resources' section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ The International Image Interoperability Framework (IIIF - "triple-eye-eff") is 
 
 ## Contents
 - [Standards](#standards)
+- [Official Resources](#resources)
 - [Image Servers](#image-servers)
 - [Image Server Shims](#image-server-shims)
 - [Image Viewers](#image-viewers)
@@ -49,6 +50,15 @@ The IIIF community has developed several standards for interoperable web-based i
 
 - [Implementations](https://github.com/IIIF/awesome-iiif/blob/master/implementations.md)
 - [Reading and Viewing](https://github.com/IIIF/awesome-iiif/blob/master/reading-viewing.md)
+
+## Official Resources
+
+The [IIIF Consortium](https://iiif.io/community/consortium/), with support from the community, maintains a number of resources to assist with understanding and implementation of IIIF.
+
+- [IIIF Cookbook](https://iiif.io/api/cookbook/) - A collection of IIIF "recipes," different reusable code snippets to help create IIIF manifests for common use cases.
+- [IIIF Guides](https://guides.iiif.io/) - a "how-to" resource with screenshots for finding IIIF Manifest URLs from various members of the IIIF community.
+- [Image API validator](https://iiif.io/api/image/validator/) - a service to validate a IIIF Image API resource against the specification.
+- [Presentation API validator](https://iiif.io/api/presentation/validator/service/) - a service to validate a IIIF Presentation API resource against the specification.
 
 ## Image Servers
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ The International Image Interoperability Framework (IIIF - "triple-eye-eff") is 
 
 ## Contents
 - [Standards](#standards)
-- [Official Resources](#resources)
+- [Official Resources](#official-resources)
 - [Image Servers](#image-servers)
 - [Image Server Shims](#image-server-shims)
 - [Image Viewers](#image-viewers)


### PR DESCRIPTION
Fixes #340 

Also adds a new "official resources" section, so additional eyes on this would be welcome -- aim here is to give easy access to tools that many folks might find useful, tools that are "officially" maintained by IIIF-C staff, but can be difficult to find on the webste
