### PR TITLE
Remove broken link in P-API Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,6 @@ These shims allow you to use systems with presentation metadata (e.g. structure 
 
 - [biiif](https://github.com/edsilv/biiif/) - Organise your files according to a simple naming convention to generate IIIF v3 manifests.
 - [demetsiiify](https://github.com/jbaiter/demetsiiify) - Web service for creating IIIF manifests from METS/MODS documents.
-- [File Analyzer IIIF Manifest Generator from Existing Metadata](http://georgetown-university-libraries.github.io/File-Analyzer-Test-Data/iiif/) - Georgetown's desktop application that will generate IIIF manifest files from existing metadata files.
 - [IIIF Download](https://www.lizmfischer.com/iiif-tools/download) - Input a IIIF Manifest URL to and the desired image size to download a zip of all that Manifest's images
 - [IIIF Manifest Explorer](https://www.lizmfischer.com/iiif-tools/manifest) - Input a IIIF manifest link to see basic object and image metadata in a human-friendly format.
 - [iiif-producer](https://github.com/ubleipzig/iiif-producer) - A CLI tool that generates IIIF Presentation 2.1 Manifests from METS/MODS (produced by Kitodo).


### PR DESCRIPTION
This item is not accessible anymore and I cannot find the new URL (if there is one): "File Analyzer IIIF Manifest Generator from Existing Metadata" (http://georgetown-university-libraries.github.io/File-Analyzer-Test-Data/iiif/)