### PR TITLE
Add Canopy IIIF to Exhibition and Guided Viewing Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@ Tools and resources that provide functionality for presenting IIIF materials in 
 
 - [Annona Range Storyboard](https://ncsu-libraries.github.io/annona/range/) - [Annona](https://ncsu-libraries.github.io/annona/) toolkit which allows for the guided viewing of segments of a manifest, in addition to the [Annona Multi Storyboard Viewer](https://ncsu-libraries.github.io/annona/multistoryboard/) for guided comparison of multiple manifests.
 - [Bloom IIIF](https://samvera-labs.github.io/bloom-iiif/) - IIIF Presentation API Collection items React.js component that renders a horizontal slider
+- [Canopy IIIF](https://github.com/mathewjordan/canopy-iiif) a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions 
 - [Curation Tools](http://codh.rois.ac.jp/software/) - Set of tools, including a Viewer, Curation Manager, Curation Board, and more from the Center for Open Data in the Humanities (all tool descriptions in Japanese, some also available in English).
 - [Exhibit](https://exhibit.so/) - A free IIIF storytelling tool that allows for guided navigation of one or more IIIF Manifests using annotations.  
 - [Micrio](https://micr.io/iiif) - High-performance client with WebAssembly/WebGL engine and additional storytelling elements. Also offering full server IIIF support.

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,7 @@ Tools and resources that provide functionality for presenting IIIF materials in 
 
 - [Annona Range Storyboard](https://ncsu-libraries.github.io/annona/range/) - [Annona](https://ncsu-libraries.github.io/annona/) toolkit which allows for the guided viewing of segments of a manifest, in addition to the [Annona Multi Storyboard Viewer](https://ncsu-libraries.github.io/annona/multistoryboard/) for guided comparison of multiple manifests.
 - [Bloom IIIF](https://samvera-labs.github.io/bloom-iiif/) - IIIF Presentation API Collection items React.js component that renders a horizontal slider
-- [Canopy IIIF](https://github.com/mathewjordan/canopy-iiif) a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions 
+- [Canopy IIIF](https://github.com/mathewjordan/canopy-iiif) - A IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions 
 - [Curation Tools](http://codh.rois.ac.jp/software/) - Set of tools, including a Viewer, Curation Manager, Curation Board, and more from the Center for Open Data in the Humanities (all tool descriptions in Japanese, some also available in English).
 - [Exhibit](https://exhibit.so/) - A free IIIF storytelling tool that allows for guided navigation of one or more IIIF Manifests using annotations.  
 - [Micrio](https://micr.io/iiif) - High-performance client with WebAssembly/WebGL engine and additional storytelling elements. Also offering full server IIIF support.


### PR DESCRIPTION
This adds Canopy IIIF to the Exhibition and Guided Viewing Tools section.
https://github.com/mathewjordan/canopy-iiif - a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions 