### PR TITLE
Update readme.md, remove superfluous version 2.1 mention for OpenLayers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ As defined by Wikipedia a shim is a small library that transparently intercepts 
 - [Imaging Helper Plugin](https://github.com/msalsbery/OpenSeadragonImagingHelper) - OpenSeadragon plugin with utility functions.
 - [IIPMooViewer](https://iipimage.sourceforge.io/documentation/iipmooviewer/) - IIPMooViewer is an open source, Javascript and HTML5 image streaming and zooming client. IIPMooViewer is IIIF-compatible and works with IIPServer or other IIIF compatible servers. [Demo](https://iipimage.sourceforge.io/demo/)
 - [Leaflet-IIIF](https://github.com/mejackreed/Leaflet-IIIF) - Lightweight, extensible IIIF image viewer.
-- [OpenLayers](https://openlayers.org) - High-performance, feature-packed Javascript library especially built for maps. It supports the IIIF Image API 2.1.
+- [OpenLayers](https://openlayers.org) - High-performance, feature-packed Javascript library especially built for maps. It supports the IIIF Image API.
 
 ## Image API Libraries
 


### PR DESCRIPTION
OpenLayers actually supports Image API versions 1.1 through 3.0.